### PR TITLE
Better Recipes

### DIFF
--- a/src/main/kotlin/com/mineinabyss/idofront/recipes/CookingRecipes.kt
+++ b/src/main/kotlin/com/mineinabyss/idofront/recipes/CookingRecipes.kt
@@ -1,4 +1,4 @@
-package com.mineinabyss.idofront.recpies
+package com.mineinabyss.idofront.recipes
 
 import org.bukkit.Bukkit
 import org.bukkit.NamespacedKey

--- a/src/main/kotlin/com/mineinabyss/idofront/serialization/SerializableItemStack.kt
+++ b/src/main/kotlin/com/mineinabyss/idofront/serialization/SerializableItemStack.kt
@@ -24,6 +24,7 @@ open class SerializableItemStack(
     var lore: String? = null,
     var damage: Int? = null,
     var prefab: String? = null,
+    var tag: String = ""
 ) {
     open fun toItemStack(applyTo: ItemStack = ItemStack(type ?: Material.AIR)) = applyTo.apply {
         prefab?.let {

--- a/src/main/kotlin/com/mineinabyss/idofront/serialization/SerializableRecipe.kt
+++ b/src/main/kotlin/com/mineinabyss/idofront/serialization/SerializableRecipe.kt
@@ -2,7 +2,6 @@ package com.mineinabyss.idofront.serialization
 
 import com.mineinabyss.idofront.util.toMCKey
 import kotlinx.serialization.Serializable
-import org.bukkit.Bukkit
 import org.bukkit.NamespacedKey
 import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.Recipe
@@ -14,10 +13,12 @@ class SerializableRecipeIngredients(
     val items: Map<String, SerializableItemStack>,
     val configuration: String,
 ) {
-    fun toCraftingRecipe(key: NamespacedKey, result: ItemStack): Recipe {
+    fun toCraftingRecipe(key: NamespacedKey, result: ItemStack, group: String): Recipe {
         val recipe = ShapedRecipe(key, result)
 
         recipe.shape(*configuration.replace("|", "").split("\n").toTypedArray())
+
+        recipe.group = group
 
         items.forEach { (key, ingredient) ->
             recipe.setIngredient(key[0], RecipeChoice.ExactChoice(ingredient.toItemStack()))
@@ -32,7 +33,8 @@ class SerializableRecipe(
     val key: String,
     val ingredients: SerializableRecipeIngredients,
     val result: SerializableItemStack,
+    val group: String = "",
 ) {
     fun toCraftingRecipe() =
-        ingredients.toCraftingRecipe(key.toMCKey(), result.toItemStack())
+        ingredients.toCraftingRecipe(key.toMCKey(), result.toItemStack(), group)
 }

--- a/src/main/kotlin/com/mineinabyss/idofront/serialization/SerializableRecipe.kt
+++ b/src/main/kotlin/com/mineinabyss/idofront/serialization/SerializableRecipe.kt
@@ -9,11 +9,11 @@ import org.bukkit.inventory.RecipeChoice
 import org.bukkit.inventory.ShapedRecipe
 
 @Serializable
-class SerializableRecipeIngredients(
+open class SerializableRecipeIngredients(
     val items: Map<String, SerializableItemStack>,
     val configuration: String,
 ) {
-    fun toCraftingRecipe(key: NamespacedKey, result: ItemStack, group: String): Recipe {
+    fun toCraftingRecipe(key: NamespacedKey, result: ItemStack, group: String = ""): Recipe {
         val recipe = ShapedRecipe(key, result)
 
         recipe.shape(*configuration.replace("|", "").split("\n").toTypedArray())

--- a/src/main/kotlin/com/mineinabyss/idofront/serialization/recipes/BlastingRecipeIngredients.kt
+++ b/src/main/kotlin/com/mineinabyss/idofront/serialization/recipes/BlastingRecipeIngredients.kt
@@ -1,0 +1,26 @@
+package com.mineinabyss.idofront.serialization.recipes
+
+import com.mineinabyss.idofront.serialization.SerializableItemStack
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import org.bukkit.NamespacedKey
+import org.bukkit.inventory.BlastingRecipe
+import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.Recipe
+import org.bukkit.inventory.RecipeChoice
+
+@Serializable
+@SerialName("blasting")
+class BlastingRecipeIngredients(
+    val input: SerializableItemStack,
+    val experience: Float,
+    val cookingTime: Int
+) : SerializableRecipeIngredients() {
+    override fun toRecipe(key: NamespacedKey, result: ItemStack, group: String): Recipe {
+        val recipe = BlastingRecipe(key, result, RecipeChoice.ExactChoice(input.toItemStack()), experience, cookingTime)
+
+        recipe.group = group
+
+        return recipe
+    }
+}

--- a/src/main/kotlin/com/mineinabyss/idofront/serialization/recipes/CampfireRecipeIngredients.kt
+++ b/src/main/kotlin/com/mineinabyss/idofront/serialization/recipes/CampfireRecipeIngredients.kt
@@ -1,0 +1,26 @@
+package com.mineinabyss.idofront.serialization.recipes
+
+import com.mineinabyss.idofront.serialization.SerializableItemStack
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import org.bukkit.NamespacedKey
+import org.bukkit.inventory.CampfireRecipe
+import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.Recipe
+import org.bukkit.inventory.RecipeChoice
+
+@Serializable
+@SerialName("campfire")
+class CampfireRecipeIngredients(
+    val input: SerializableItemStack,
+    val experience: Float,
+    val cookingTime: Int
+) : SerializableRecipeIngredients() {
+    override fun toRecipe(key: NamespacedKey, result: ItemStack, group: String): Recipe {
+        val recipe = CampfireRecipe(key, result, RecipeChoice.ExactChoice(input.toItemStack()), experience, cookingTime)
+
+        recipe.group = group
+
+        return recipe
+    }
+}

--- a/src/main/kotlin/com/mineinabyss/idofront/serialization/recipes/FurnaceRecipeIngredients.kt
+++ b/src/main/kotlin/com/mineinabyss/idofront/serialization/recipes/FurnaceRecipeIngredients.kt
@@ -1,0 +1,26 @@
+package com.mineinabyss.idofront.serialization.recipes
+
+import com.mineinabyss.idofront.serialization.SerializableItemStack
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import org.bukkit.NamespacedKey
+import org.bukkit.inventory.FurnaceRecipe
+import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.Recipe
+import org.bukkit.inventory.RecipeChoice
+
+@Serializable
+@SerialName("furnace")
+class FurnaceRecipeIngredients(
+    val input: SerializableItemStack,
+    val experience: Float,
+    val cookingTime: Int
+) : SerializableRecipeIngredients() {
+    override fun toRecipe(key: NamespacedKey, result: ItemStack, group: String): Recipe {
+        val recipe = FurnaceRecipe(key, result, RecipeChoice.ExactChoice(input.toItemStack()), experience, cookingTime)
+
+        recipe.group = group
+
+        return recipe
+    }
+}

--- a/src/main/kotlin/com/mineinabyss/idofront/serialization/recipes/SerializableRecipe.kt
+++ b/src/main/kotlin/com/mineinabyss/idofront/serialization/recipes/SerializableRecipe.kt
@@ -1,0 +1,16 @@
+package com.mineinabyss.idofront.serialization.recipes
+
+import com.mineinabyss.idofront.serialization.SerializableItemStack
+import com.mineinabyss.idofront.util.toMCKey
+import kotlinx.serialization.Serializable
+
+@Serializable
+class SerializableRecipe(
+    val key: String,
+    val ingredients: SerializableRecipeIngredients,
+    val result: SerializableItemStack,
+    val group: String = "",
+) {
+    fun toCraftingRecipe() =
+        ingredients.toRecipe(key.toMCKey(), result.toItemStack(), group)
+}

--- a/src/main/kotlin/com/mineinabyss/idofront/serialization/recipes/SerializableRecipeIngredients.kt
+++ b/src/main/kotlin/com/mineinabyss/idofront/serialization/recipes/SerializableRecipeIngredients.kt
@@ -1,0 +1,11 @@
+package com.mineinabyss.idofront.serialization.recipes
+
+import kotlinx.serialization.Serializable
+import org.bukkit.NamespacedKey
+import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.Recipe
+
+@Serializable
+sealed class SerializableRecipeIngredients {
+    abstract fun toRecipe(key: NamespacedKey, result: ItemStack, group: String = ""): Recipe
+}

--- a/src/main/kotlin/com/mineinabyss/idofront/serialization/recipes/ShapedRecipeIngredients.kt
+++ b/src/main/kotlin/com/mineinabyss/idofront/serialization/recipes/ShapedRecipeIngredients.kt
@@ -1,6 +1,7 @@
-package com.mineinabyss.idofront.serialization
+package com.mineinabyss.idofront.serialization.recipes
 
-import com.mineinabyss.idofront.util.toMCKey
+import com.mineinabyss.idofront.serialization.SerializableItemStack
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import org.bukkit.NamespacedKey
 import org.bukkit.inventory.ItemStack
@@ -9,11 +10,12 @@ import org.bukkit.inventory.RecipeChoice
 import org.bukkit.inventory.ShapedRecipe
 
 @Serializable
-open class SerializableRecipeIngredients(
+@SerialName("shaped")
+class ShapedRecipeIngredients(
     val items: Map<String, SerializableItemStack>,
-    val configuration: String,
-) {
-    fun toCraftingRecipe(key: NamespacedKey, result: ItemStack, group: String = ""): Recipe {
+    val configuration: String = "",
+) : SerializableRecipeIngredients() {
+    override fun toRecipe(key: NamespacedKey, result: ItemStack, group: String): Recipe {
         val recipe = ShapedRecipe(key, result)
 
         recipe.shape(*configuration.replace("|", "").split("\n").toTypedArray())
@@ -26,15 +28,4 @@ open class SerializableRecipeIngredients(
 
         return recipe
     }
-}
-
-@Serializable
-class SerializableRecipe(
-    val key: String,
-    val ingredients: SerializableRecipeIngredients,
-    val result: SerializableItemStack,
-    val group: String = "",
-) {
-    fun toCraftingRecipe() =
-        ingredients.toCraftingRecipe(key.toMCKey(), result.toItemStack(), group)
 }

--- a/src/main/kotlin/com/mineinabyss/idofront/serialization/recipes/ShapedRecipeIngredients.kt
+++ b/src/main/kotlin/com/mineinabyss/idofront/serialization/recipes/ShapedRecipeIngredients.kt
@@ -3,7 +3,10 @@ package com.mineinabyss.idofront.serialization.recipes
 import com.mineinabyss.idofront.serialization.SerializableItemStack
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import org.bukkit.Bukkit
+import org.bukkit.Material
 import org.bukkit.NamespacedKey
+import org.bukkit.Tag
 import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.Recipe
 import org.bukkit.inventory.RecipeChoice
@@ -23,7 +26,20 @@ class ShapedRecipeIngredients(
         recipe.group = group
 
         items.forEach { (key, ingredient) ->
-            recipe.setIngredient(key[0], RecipeChoice.ExactChoice(ingredient.toItemStack()))
+            if (ingredient.tag !== "") {
+                recipe.setIngredient(
+                    key[0],
+                    RecipeChoice.MaterialChoice(
+                        Bukkit.getTag(
+                            Tag.REGISTRY_BLOCKS,
+                            NamespacedKey.minecraft(ingredient.tag),
+                            Material::class.java
+                        )
+                    )
+                )
+            } else {
+                recipe.setIngredient(key[0], RecipeChoice.ExactChoice(ingredient.toItemStack()))
+            }
         }
 
         return recipe

--- a/src/main/kotlin/com/mineinabyss/idofront/serialization/recipes/ShapelessRecipeIngredients.kt
+++ b/src/main/kotlin/com/mineinabyss/idofront/serialization/recipes/ShapelessRecipeIngredients.kt
@@ -3,7 +3,10 @@ package com.mineinabyss.idofront.serialization.recipes
 import com.mineinabyss.idofront.serialization.SerializableItemStack
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import org.bukkit.Bukkit
+import org.bukkit.Material
 import org.bukkit.NamespacedKey
+import org.bukkit.Tag
 import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.Recipe
 import org.bukkit.inventory.RecipeChoice
@@ -20,7 +23,19 @@ class ShapelessRecipeIngredients(
         recipe.group = group
 
         items.forEach { ingredient ->
-            recipe.addIngredient(RecipeChoice.ExactChoice(ingredient.toItemStack()))
+            if (ingredient.tag !== "") {
+                recipe.addIngredient(
+                    RecipeChoice.MaterialChoice(
+                        Bukkit.getTag(
+                            Tag.REGISTRY_BLOCKS,
+                            NamespacedKey.minecraft(ingredient.tag),
+                            Material::class.java
+                        )
+                    )
+                )
+            } else {
+                recipe.addIngredient(RecipeChoice.ExactChoice(ingredient.toItemStack()))
+            }
         }
 
         return recipe

--- a/src/main/kotlin/com/mineinabyss/idofront/serialization/recipes/ShapelessRecipeIngredients.kt
+++ b/src/main/kotlin/com/mineinabyss/idofront/serialization/recipes/ShapelessRecipeIngredients.kt
@@ -1,0 +1,28 @@
+package com.mineinabyss.idofront.serialization.recipes
+
+import com.mineinabyss.idofront.serialization.SerializableItemStack
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import org.bukkit.NamespacedKey
+import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.Recipe
+import org.bukkit.inventory.RecipeChoice
+import org.bukkit.inventory.ShapelessRecipe
+
+@Serializable
+@SerialName("shapeless")
+class ShapelessRecipeIngredients(
+    val items: List<SerializableItemStack>,
+) : SerializableRecipeIngredients() {
+    override fun toRecipe(key: NamespacedKey, result: ItemStack, group: String): Recipe {
+        val recipe = ShapelessRecipe(key, result)
+
+        recipe.group = group
+
+        items.forEach { ingredient ->
+            recipe.addIngredient(RecipeChoice.ExactChoice(ingredient.toItemStack()))
+        }
+
+        return recipe
+    }
+}

--- a/src/main/kotlin/com/mineinabyss/idofront/serialization/recipes/SmithingRecipeIngredients.kt
+++ b/src/main/kotlin/com/mineinabyss/idofront/serialization/recipes/SmithingRecipeIngredients.kt
@@ -1,0 +1,26 @@
+package com.mineinabyss.idofront.serialization.recipes
+
+import com.mineinabyss.idofront.serialization.SerializableItemStack
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import org.bukkit.NamespacedKey
+import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.Recipe
+import org.bukkit.inventory.RecipeChoice
+import org.bukkit.inventory.SmithingRecipe
+
+@Serializable
+@SerialName("smithing")
+class SmithingRecipeIngredients(
+    val input: SerializableItemStack,
+    val addition: SerializableItemStack,
+) : SerializableRecipeIngredients() {
+    override fun toRecipe(key: NamespacedKey, result: ItemStack, group: String): Recipe {
+        return SmithingRecipe(
+            key,
+            result,
+            RecipeChoice.ExactChoice(input.toItemStack()),
+            RecipeChoice.ExactChoice(addition.toItemStack())
+        )
+    }
+}

--- a/src/main/kotlin/com/mineinabyss/idofront/serialization/recipes/SmokingRecipeIngredients.kt
+++ b/src/main/kotlin/com/mineinabyss/idofront/serialization/recipes/SmokingRecipeIngredients.kt
@@ -1,0 +1,26 @@
+package com.mineinabyss.idofront.serialization.recipes
+
+import com.mineinabyss.idofront.serialization.SerializableItemStack
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import org.bukkit.NamespacedKey
+import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.Recipe
+import org.bukkit.inventory.RecipeChoice
+import org.bukkit.inventory.SmokingRecipe
+
+@Serializable
+@SerialName("smoking")
+class SmokingRecipeIngredients(
+    val input: SerializableItemStack,
+    val experience: Float,
+    val cookingTime: Int
+) : SerializableRecipeIngredients() {
+    override fun toRecipe(key: NamespacedKey, result: ItemStack, group: String): Recipe {
+        val recipe = SmokingRecipe(key, result, RecipeChoice.ExactChoice(input.toItemStack()), experience, cookingTime)
+
+        recipe.group = group
+
+        return recipe
+    }
+}

--- a/src/main/kotlin/com/mineinabyss/idofront/serialization/recipes/StonecuttingRecipeIngredients.kt
+++ b/src/main/kotlin/com/mineinabyss/idofront/serialization/recipes/StonecuttingRecipeIngredients.kt
@@ -1,0 +1,24 @@
+package com.mineinabyss.idofront.serialization.recipes
+
+import com.mineinabyss.idofront.serialization.SerializableItemStack
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import org.bukkit.NamespacedKey
+import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.Recipe
+import org.bukkit.inventory.RecipeChoice
+import org.bukkit.inventory.StonecuttingRecipe
+
+@Serializable
+@SerialName("stonecutting")
+class StonecuttingRecipeIngredients(
+    val input: SerializableItemStack,
+) : SerializableRecipeIngredients() {
+    override fun toRecipe(key: NamespacedKey, result: ItemStack, group: String): Recipe {
+        val recipe = StonecuttingRecipe(key, result, RecipeChoice.ExactChoice(input.toItemStack()))
+
+        recipe.group = group
+
+        return recipe
+    }
+}


### PR DESCRIPTION
Allow for more recipe types to be used in looty


```diff
+ Group support
+ Tag support
+ New recipe types
```

Allowed types (see com.mineinabyss.idofront.serialization.recipes):
```
shaped
shapeless
smithing // only affects the item id and does not change nbt :(
blasting
furnace
campfire
stonecutting
```

Fixes https://github.com/MineInAbyss/Looty/issues/22