### PR TITLE
Overwrite on CopyJar task

### DIFF
--- a/idofront-gradle/src/main/kotlin/com.mineinabyss.conventions.copyjar.gradle.kts
+++ b/idofront-gradle/src/main/kotlin/com.mineinabyss.conventions.copyjar.gradle.kts
@@ -19,6 +19,7 @@ val copyJar = project.extensions.create<CopyJarExtension>("copyJar")
 if (pluginPath != null) {
     tasks {
         register<Copy>("copyJar") {
+            doNotTrackState("Overwrites the plugin jar to allow for easier reloading")
             val dest = copyJar.destPath.orNull ?: pluginPath
             val jarName = copyJar.jarName.orNull ?: "${project.name}-${project.version}.jar"
 


### PR DESCRIPTION
In Gradle 8.0 it seems that unless explicitly stated, the build-task will fail as the server is "using the jar"
Just restores old CopyJar behaviour where it will always override the current file
![image](https://github.com/MineInAbyss/Idofront/assets/62521371/68821135-2970-4d3c-9acd-e33213d78f70)
