### PR TITLE
fix: Unbreakable now supported in toItemStack

### DIFF
--- a/idofront-serializers/src/main/kotlin/com/mineinabyss/idofront/serialization/SerializableItemStack.kt
+++ b/idofront-serializers/src/main/kotlin/com/mineinabyss/idofront/serialization/SerializableItemStack.kt
@@ -233,6 +233,8 @@ data class BaseSerializableItemStack(
         potDecorations?.setDataType(applyTo)
 
         SerializableDataTypes.setData(applyTo, DataComponentTypes.INTANGIBLE_PROJECTILE, intangibleProjectile)
+        SerializableDataTypes.setData(applyTo, DataComponentTypes.GLIDER, glider)
+        SerializableDataTypes.setData(applyTo, DataComponentTypes.UNBREAKABLE, unbreakable)
 
         return applyTo
     }
@@ -318,6 +320,7 @@ fun ItemStack.toSerializable(): SerializableItemStack = with(itemMeta) {
         potDecorations = dataIfOverriden(DataComponentTypes.POT_DECORATIONS)?.let(SerializableDataTypes::PotDecorations),
 
         intangibleProjectile = SerializableDataTypes.IntangibleProjectile.takeIf { hasData(DataComponentTypes.INTANGIBLE_PROJECTILE) },
+        glider = SerializableDataTypes.Glider.takeIf { hasData(DataComponentTypes.GLIDER) },
         unbreakable = SerializableDataTypes.Unbreakable.takeIf { hasData(DataComponentTypes.UNBREAKABLE) },
 
     )


### PR DESCRIPTION
This fixes a couple gaps with the glider and unbreakable unvalued datatypes.